### PR TITLE
doc: Fixing urls to match new ones (grip-framework)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,7 +20,7 @@ Then add *Grip* to your `shard.yml` file as a dependencie.
 ```yaml
 dependencies:
     grip:
-        github: grkek/grip
+        github: grip-framework/grip
 ```
 
 Finally run `shards` to get the dependencies:
@@ -185,7 +185,7 @@ Plug middleware is the building block of the framework, some helpful plugs are i
 ```ruby
 class Custom < Grip::Pipe::Base
   def call(context)
-    
+
   end
 end
 
@@ -509,14 +509,14 @@ crystal build --release src/your_app.cr
 
 [spec-kemal](https://github.com/kemalcr/spec-kemal) has been forked to make testing easy.
 
-Add [*spec-grip*](https://github.com/Whaxion/spec-grip) to your `shard.yml` file as a dependencie.
+Add [*spec-grip*](https://github.com/grip-framework/spec-grip) to your `shard.yml` file as a dependencie.
 
 ```yaml
 dependencies:
     grip:
-        github: grkek/grip
+        github: grip-framework/grip
     spec-grip:
-        github: Whaxion/spec-grip
+        github: grip-framework/spec-grip
 ```
 
 Then run `shards` to get the dependencies:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-[![Grip](https://avatars0.githubusercontent.com/u/44188195?s=200&v=4)](https://github.com/grkek/grip)
+[![Grip](https://avatars0.githubusercontent.com/u/44188195?s=200&v=4)](https://github.com/grip-framework/grip)
 
 # Grip
 
 Class oriented fork of the [Kemal](https://kemalcr.com) framework based on a JSON request/response model.
 
-Currently Grip is headed towards a JSON request/response type interface, which makes this framework non-HTML friendly, 
+Currently Grip is headed towards a JSON request/response type interface, which makes this framework non-HTML friendly,
 it is still possible to render HTML but it is not advised to use Grip for that purpose.
 
 So far at **285,013** requests/second, and still [going](https://github.com/the-benchmarker/web-frameworks).
@@ -35,7 +35,7 @@ class Index < Grip::Controller::Http
     puts query(context) # This gets the query parameters passed in with the url
     puts json(context) # This gets the JSON data which was passed into the route
     puts headers(context) # This gets the http headers
-    
+
     params = url(context)
 
     json(
@@ -74,7 +74,7 @@ id_api = IdApi.new
 id_api.run
 ```
 
-The default port of the application is `3000`, 
+The default port of the application is `3000`,
 you can set it by either compiling it and providing a `-p` flag or
 by changing it from the source code.
 
@@ -101,7 +101,7 @@ dependencies:
 # Documentation
 
 - For the framework development just use the `crystal docs` feature and browse through the module.
-- Check out the official documentation available [here](https://github.com/grkek/grip/blob/master/DOCUMENTATION.md)
+- Check out the official documentation available [here](https://github.com/grip-framework/grip/blob/master/DOCUMENTATION.md)
 
 ## Thanks
 


### PR DESCRIPTION
### Description of the Change
I've changed the urls to match the new ones because grip has been moved to grip-framework organization
