### PR TITLE
Add a websocket close code (Crystal 0.34.0 compatibility)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -427,8 +427,8 @@ class Echo < Grip::Controller::WebSocket
     socket.send message
   end
 
-  def on_close(context, socket, message)
-    puts message
+  def on_close(context, socket, code, message)
+    puts code, message
   end
 end
 
@@ -456,8 +456,8 @@ class Echo < Grip::Controller::WebSocket
     socket.send message
   end
 
-  def on_close(context, socket, message)
-    puts message
+  def on_close(context, socket, code, message)
+    puts code, message
   end
 end
 
@@ -485,8 +485,8 @@ class Echo < Grip::Controller::WebSocket
     socket.send message
   end
 
-  def on_close(context, socket, message)
-    puts message
+  def on_close(context, socket, code, message)
+    puts code, message
   end
 end
 

--- a/shard.yml
+++ b/shard.yml
@@ -16,6 +16,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.10.0
 
-crystal: 0.33.0
+crystal: 0.34.0
 
 license: MIT


### PR DESCRIPTION
### Description of the Change

Crystal 0.34.0 has introduced a breaking change to the WebSocket close handling.  This changeset applies some of the changes made to the Crystal [`HTTP::WebSocket`](https://github.com/crystal-lang/crystal/blob/0.34.0/src/http/web_socket.cr) during that release.

See also: https://crystal-lang.org/2020/04/06/crystal-0.34.0-released.html

### Benefits

Applications using Grip can be built with Crystal 0.34.0 and are ready for the future.

### Possible Drawbacks

Crystal versions older than 0.34.0 will be unsupported.

Also, all subclasses of `Grip::Controller::WebSocket` need to change their `on_close` signature to match with the updated one.
