### PR TITLE
Move the forward handler out of the http handler

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: grip
-version: 1.0.1
+version: 1.0.2
 
 authors:
   - Grip and its Contributors <https://github.com/grip-framework/>

--- a/src/grip.cr
+++ b/src/grip.cr
@@ -30,3 +30,35 @@ require "./grip/routers/*"
 require "./grip/*"
 
 module Grip; end
+
+class Authorization < Grip::Controllers::Base
+  def initialize(@username : String, @password : String); end
+
+  def call(context : Context) : Context
+    context
+      .put_status(201)
+      .json({username: @username, password: @password})
+      .halt
+  end
+end
+
+class ProtectedController < Grip::Controllers::Http
+  def get(context)
+    context
+      .put_status(200)
+      .json({status: 200, message: "You are accessing a protected resource"})
+      .halt
+  end
+end
+
+class Application < Grip::Application
+  def routes
+    # Forward macro simply routes the matched requests to a certain Base controller
+    # which contains a single call/1 function.
+    forward "/", Authorization, username: "admin", password: "admin"
+    get "/:id", ProtectedController
+  end
+end
+
+app = Application.new
+app.run

--- a/src/grip.cr
+++ b/src/grip.cr
@@ -30,35 +30,3 @@ require "./grip/routers/*"
 require "./grip/*"
 
 module Grip; end
-
-class Authorization < Grip::Controllers::Base
-  def initialize(@username : String, @password : String); end
-
-  def call(context : Context) : Context
-    context
-      .put_status(201)
-      .json({username: @username, password: @password})
-      .halt
-  end
-end
-
-class ProtectedController < Grip::Controllers::Http
-  def get(context)
-    context
-      .put_status(200)
-      .json({status: 200, message: "You are accessing a protected resource"})
-      .halt
-  end
-end
-
-class Application < Grip::Application
-  def routes
-    # Forward macro simply routes the matched requests to a certain Base controller
-    # which contains a single call/1 function.
-    forward "/", Authorization, username: "admin", password: "admin"
-    get "/:id", ProtectedController
-  end
-end
-
-app = Application.new
-app.run

--- a/src/grip/application.cr
+++ b/src/grip/application.cr
@@ -23,6 +23,7 @@ module Grip
     private property exception_handler : Grip::Handlers::Exception
     private property pipeline_handler : Grip::Handlers::Pipeline
     private property websocket_handler : Grip::Routers::WebSocket
+    private property forward_handler : Grip::Handlers::Forward
 
     private property scopes : Array(String) = [] of String
     private property valves : Array(Symbol) = [] of Symbol
@@ -36,6 +37,7 @@ module Grip
       @websocket_handler = Grip::Routers::WebSocket.new
       @pipeline_handler = Grip::Handlers::Pipeline.new(@http_handler, @websocket_handler)
       @exception_handler = Grip::Handlers::Exception.new
+      @forward_handler = Grip::Handlers::Forward.new
       @swagger_builder = Swagger::Builder.new(
         title: title(),
         version: version(),
@@ -107,6 +109,7 @@ module Grip
       [
         @exception_handler,
         @pipeline_handler,
+        @forward_handler,
         @websocket_handler,
         @http_handler,
       ] of HTTP::Handler

--- a/src/grip/dsl/macros.cr
+++ b/src/grip/dsl/macros.cr
@@ -94,7 +94,7 @@ module Grip
       {% end %}
 
       macro forward(route, resource, **kwargs)
-        @http_handler.add_route(
+        @forward_handler.add_route(
           "ALL",
           "#{@scopes.join()}#{{{route}}}",
           {{resource}}.new({{**kwargs}}).as(Grip::Controllers::Base),


### PR DESCRIPTION
Moved the forward handler out of the http handler to clean up the code and create a better structure in general, the merged handler was causing performance issues since it actually needs to calculate the route 2 times.