### PR TITLE
Add possiblity to add cookies from context

### DIFF
--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -137,4 +137,59 @@ describe "Context" do
       client_response.headers["Content-Type"].should eq "multipart/encrypted"
     end
   end
+
+  context "cookies" do
+    it "sets cookie" do
+      http_handler = Grip::Routers::Http.new
+      http_handler.add_route "GET", "/cookies", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do
+        context.put_resp_cookie(HTTP::Cookie.new("Foo", "Bar")).halt
+      end
+
+      request = HTTP::Request.new("GET", "/cookies")
+      client_response = call_request_on_app(request, http_handler)
+
+      client_response.cookies.size.should eq(1)
+      client_response.cookies["Foo"].value.should eq("Bar")
+    end
+
+    it "sets string cookie" do
+      http_handler = Grip::Routers::Http.new
+      http_handler.add_route "GET", "/cookies", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do
+        context.put_resp_cookie("Foo", "Bar").halt
+      end
+
+      request = HTTP::Request.new("GET", "/cookies")
+      client_response = call_request_on_app(request, http_handler)
+
+      client_response.cookies.size.should eq(1)
+      client_response.cookies["Foo"].value.should eq("Bar")
+    end
+
+    it "sets multiple cookie" do
+      http_handler = Grip::Routers::Http.new
+      http_handler.add_route "GET", "/cookies", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do
+        context.put_resp_cookie("Foo", "Bar").put_resp_cookie("Qux", "Baz").halt
+      end
+
+      request = HTTP::Request.new("GET", "/cookies")
+      client_response = call_request_on_app(request, http_handler)
+
+      client_response.cookies.size.should eq(2)
+      client_response.cookies["Foo"].value.should eq("Bar")
+      client_response.cookies["Qux"].value.should eq("Baz")
+    end
+
+    it "overrides cookie" do
+      http_handler = Grip::Routers::Http.new
+      http_handler.add_route "GET", "/cookies", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do
+        context.put_resp_cookie("Foo", "Bar").put_resp_cookie("Foo", "Baz").halt
+      end
+
+      request = HTTP::Request.new("GET", "/cookies")
+      client_response = call_request_on_app(request, http_handler)
+
+      client_response.cookies.size.should eq(1)
+      client_response.cookies["Foo"].value.should eq("Baz")
+    end
+  end
 end

--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -50,6 +50,18 @@ module Grip
         self
       end
 
+      # Sets response cookie
+      def put_resp_cookie(cookie)
+        @response.cookies[cookie.name] = cookie
+        self
+      end
+
+      # Sets response cookie from string
+      def put_resp_cookie(key, val)
+        @response.cookies[key] = val
+        self
+      end
+
       # Assigns response status code.
       def put_status(status_code = HTTP::Status::OK)
         @response.status_code = status_code.to_i


### PR DESCRIPTION
### Description of the Change

This change introduces a new method `put_resp_cookie` for `Context` class. The method either accepts a string key and and string value which will be converted by `HTTP::Cookies` to a cookie or it directly accepts a `HTTP::Cookie` which is added to the response cookies.

### Alternate Designs

I could have added a cookie by adding a header, but as there is already the possibility to directly add cookies directly to the response this is my preferred solution.

### Benefits

This solution adds a simpler way of adding cookies to the response
