### PR TITLE
Fix the missing parameters during middleware requests

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: grip
-version: 1.0.2
+version: 1.0.3
 
 authors:
   - Grip and its Contributors <https://github.com/grip-framework/>

--- a/src/grip/handlers/pipeline.cr
+++ b/src/grip/handlers/pipeline.cr
@@ -54,6 +54,7 @@ module Grip
           return false
         end
 
+        context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
         route.payload.match_via_keyword(context, self)
 
         true
@@ -68,6 +69,8 @@ module Grip
         unless route.found?
           return false
         end
+
+        context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
         route.payload.match_via_keyword(context, self)
 
         true

--- a/src/grip/routers/http.cr
+++ b/src/grip/routers/http.cr
@@ -32,10 +32,10 @@ module Grip
 
         if payload.override
           payload.call_into_override(context)
-          return context
+          context
         else
           payload.handler.call(context)
-          return context
+          context
         end
       end
 

--- a/src/grip/routers/http.cr
+++ b/src/grip/routers/http.cr
@@ -18,20 +18,25 @@ module Grip
           context.request.path
         )
 
-        if route.found?
-          context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
-          payload = route.payload
-
-          if payload.override
-            payload.call_into_override(context)
-            return context
-          else
-            payload.handler.call(context)
-            return context
-          end
+        unless route.found?
+          raise Exceptions::NotFound.new
         end
 
-        raise Exceptions::NotFound.new if !route.found?
+        if context.parameters
+          # Continue the execution since the parameters already exist.
+        else
+          context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
+        end
+
+        payload = route.payload
+
+        if payload.override
+          payload.call_into_override(context)
+          return context
+        else
+          payload.handler.call(context)
+          return context
+        end
       end
 
       def add_route(method : String, path : String, handler : Grip::Controllers::Base, via : Symbol? | Array(Symbol)?, override : Proc(HTTP::Server::Context, HTTP::Server::Context)?) : Void

--- a/src/grip/routers/websocket.cr
+++ b/src/grip/routers/websocket.cr
@@ -17,7 +17,12 @@ module Grip
           return call_next(context)
         end
 
-        context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
+        if context.parameters
+          # Continue the execution since the parameters already exist.
+        else
+          context.parameters = Grip::Parsers::ParameterBox.new(context.request, route.params)
+        end
+
         payload = route.payload
 
         payload.handler.call(context)


### PR DESCRIPTION
This PR fixes the missing parameters which was caused by pipelines not parsing using the `ParameterBox`