### PR TITLE
Add redirect to context

### DIFF
--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -118,6 +118,17 @@ module Grip
           @parameters.not_nil!.url
         end
       end
+
+      def redirect(url)
+        redirect(url, 302)
+        self
+      end
+
+      def redirect(url, status)
+        @response.headers.add "Location", "/"
+        put_status status
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

This pull request adds a `redirect` method to the `Context` class which accepts a redirect url and a optional HTTP status.

### Alternate Designs

The user has to manually add the header and status to the response

### Benefits

Shortcut to use a redirect and taking the design of the Grip Context into consideration.

### Possible Drawbacks

None that I would know of. Only downside - I don't know how to write a test for it. I tested it locally on my project, but I don't know how to redirect in the specs. 
