### PR TITLE
Update macros.cr

### DIFF
--- a/src/grip/dsl/macros.cr
+++ b/src/grip/dsl/macros.cr
@@ -65,7 +65,7 @@ module Grip
             \{% if route_annotation && controller_annotation %}
               @swagger_builder.add(
                 Swagger::Controller.new(
-                  "#{\{{ resource }}.to_s}",
+                  \{{ controller_annotation[:name] }} || "#{\{{ resource }}.to_s}",
                   \{{ controller_annotation[:description] }},
                   [
                     Swagger::Action.new(


### PR DESCRIPTION
### Description of the Change

Updated the macro for swagger documentation generation so that the controller annotation can be viewed with an optional name. If no name is supplied the default is still the resource. 

### Alternate Designs

none its a 1 line change. 

### Benefits

Adds the ability to set the route name in the swagger docs to be more readable and understandable. 

### Possible Drawbacks

none that i found. 
