### PR TITLE
Use controller singleton to handle all requests

### DIFF
--- a/src/grip/controllers/base.cr
+++ b/src/grip/controllers/base.cr
@@ -1,7 +1,6 @@
 module Grip
   module Controllers
     abstract class Base
-      include HTTP::Handler
       alias Context = HTTP::Server::Context
 
       abstract def call(context : Context) : Context

--- a/src/grip/controllers/exception.cr
+++ b/src/grip/controllers/exception.cr
@@ -1,13 +1,9 @@
+require "./singleton"
+
 module Grip
   module Controllers
     abstract class Exception < Base
-      macro inherited
-        @@instance = new
-
-        def self.instance
-          @@instance
-        end
-      end
+      include Singleton
 
       abstract def call(context : Context) : Context
     end

--- a/src/grip/controllers/exception.cr
+++ b/src/grip/controllers/exception.cr
@@ -1,6 +1,14 @@
 module Grip
   module Controllers
     abstract class Exception < Base
+      macro inherited
+        @@instance = new
+
+        def self.instance
+          @@instance
+        end
+      end
+
       abstract def call(context : Context) : Context
     end
   end

--- a/src/grip/controllers/http.cr
+++ b/src/grip/controllers/http.cr
@@ -1,6 +1,14 @@
 module Grip
   module Controllers
     class Http < Base
+      macro inherited
+        @@instance = new
+
+        def self.instance
+          @@instance
+        end
+      end
+
       def get(context : Context) : Context
         context
           .halt

--- a/src/grip/controllers/http.cr
+++ b/src/grip/controllers/http.cr
@@ -1,13 +1,9 @@
+require "./singleton"
+
 module Grip
   module Controllers
     class Http < Base
-      macro inherited
-        @@instance = new
-
-        def self.instance
-          @@instance
-        end
-      end
+      include Singleton
 
       def get(context : Context) : Context
         context

--- a/src/grip/controllers/singleton.cr
+++ b/src/grip/controllers/singleton.cr
@@ -1,0 +1,15 @@
+module Grip
+  module Controllers
+    module Singleton
+      macro included
+        macro inherited
+          @@instance = new
+
+          def self.instance
+            @@instance
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/grip/controllers/swagger.cr
+++ b/src/grip/controllers/swagger.cr
@@ -1,13 +1,9 @@
+require "./singleton"
+
 module Grip
   module Controllers
     class Swagger < Grip::Controllers::Base
-      macro inherited
-        @@instance = new
-
-        def self.instance
-          @@instance
-        end
-      end
+      include Singleton
 
       property document : ::Swagger::Builder
       property base_path : String

--- a/src/grip/controllers/swagger.cr
+++ b/src/grip/controllers/swagger.cr
@@ -1,6 +1,14 @@
 module Grip
   module Controllers
     class Swagger < Grip::Controllers::Base
+      macro inherited
+        @@instance = new
+
+        def self.instance
+          @@instance
+        end
+      end
+
       property document : ::Swagger::Builder
       property base_path : String
 

--- a/src/grip/controllers/websocket.cr
+++ b/src/grip/controllers/websocket.cr
@@ -1,6 +1,14 @@
 module Grip
   module Controllers
     abstract class WebSocket < Grip::Controllers::Base
+      macro inherited
+        @@instance = new
+
+        def self.instance
+          @@instance
+        end
+      end
+
       alias Socket = HTTP::WebSocket::Protocol
       getter? closed = false
 

--- a/src/grip/controllers/websocket.cr
+++ b/src/grip/controllers/websocket.cr
@@ -1,13 +1,9 @@
+require "./singleton"
+
 module Grip
   module Controllers
     abstract class WebSocket < Grip::Controllers::Base
-      macro inherited
-        @@instance = new
-
-        def self.instance
-          @@instance
-        end
-      end
+      include Singleton
 
       alias Socket = HTTP::WebSocket::Protocol
       getter? closed = false

--- a/src/grip/dsl/macros.cr
+++ b/src/grip/dsl/macros.cr
@@ -43,17 +43,17 @@ module Grip
             @http_handler.add_route(
               {{http_method}}.to_s.upcase,
               "#{@scopes.join()}#{\{{route}}}",
-              \{{resource}}.new.as(Grip::Controllers::Base),
+              \{{resource}}.instance.as(Grip::Controllers::Base),
               @valves.clone(),
               -> (context : HTTP::Server::Context) {
-                \{{ resource }}.new.as(\{{resource}}).\{{kwargs[:as].id}}(context)
+                \{{ resource }}.instance.\{{kwargs[:as].id}}(context)
               }
             )
           \{% else %}
             @http_handler.add_route(
               {{http_method}}.to_s.upcase,
               "#{@scopes.join()}#{\{{route}}}",
-              \{{resource}}.new.as(Grip::Controllers::Base),
+              \{{resource}}.instance.as(Grip::Controllers::Base),
               @valves.clone(),
               nil
             )


### PR DESCRIPTION
### Description of the Change
This PR addresses issue from #48

Currently, for routes without method override, it uses the same controller instance on the route to handle all matching requests.

A new instance would be created when you add the same controller to another route.

This PR makes all routes with the same controller class to use the singleton instance to handle all matching requests.

Each controller would only need to be instantiated once.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs
Closured local controller instances would also work but it still creates multiple instances of the same controller.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Only need one instance per controller to handle all matching requests. Less memory allocation, especially compared with the original override Proc which instantiates a new controller instance for each matching request.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
One should not use any instance variables in the controller as a single instance would be used to handle multiple concurrent requests. But this is already a limitation to the non-override route for which a single controller instance is used to handle all matching requests.
<!-- What are the possible side-effects or negative impacts of the code change? -->
