### PR TITLE
Add helper method exec to Context

### DIFF
--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -142,6 +142,10 @@ module Grip
         @response.status_code = status_code.to_i
         self
       end
+
+      def exec
+        with self yield
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

@grkek

Add helper method `exec` to Context to allow the block to run in context scope.

It's similar to Ruby's `instance_exec`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

One can call methods on Context instance without chaining:
```
class DemoController < Grip::Controllers::Http
  def get(context : Context)
    context.exec do
      put_status(201) # Put a response status code.
      put_resp_header("Server", "TornadoServer/6.0.4") # Put a response header.
      json( # Respond with JSON encoded data.
        {
          "id" => 1
        }
      )
    end
  end
end
```

### Possible Drawbacks

It might slow down performance? I'm not sure.