### PR TITLE
Update application.cr

### DIFF
--- a/src/grip/application.cr
+++ b/src/grip/application.cr
@@ -118,14 +118,8 @@ module Grip
       Log.info { "Listening at #{schema}://#{host}:#{port}" }
 
       if @environment != "test"
-        setup_trap_signal()
+        Process.on_interrupt { exit }
         server.listen
-      end
-    end
-
-    private def setup_trap_signal
-      Signal::INT.trap do
-        exit
       end
     end
   end

--- a/src/grip/handlers/static.cr
+++ b/src/grip/handlers/static.cr
@@ -26,7 +26,7 @@ module Grip
         end
 
         is_dir_path = dir_path? original_path
-        expanded_path = File.expand_path(request_path, "/")
+        expanded_path = Path.posix(request_path).expand("/").to_s
         expanded_path += "/" if is_dir_path && !dir_path?(expanded_path)
         is_dir_path = dir_path? expanded_path
         file_path = File.join(@public_dir, expanded_path)


### PR DESCRIPTION
Now the error `Not Implemented: Crystal::System::Signal.trap (NotImplementedError)` will occur at runtime on Windows. The platform-agnostic API is preferred.