### PR TITLE
fix pipeline scope propagation

### DIFF
--- a/src/grip/macros/dsl.cr
+++ b/src/grip/macros/dsl.cr
@@ -18,7 +18,7 @@ module Grip
       end
 
       macro scope(path)
-        size = @valves.size
+        %size = @valves.size
 
         if {{path}} != "/"
           @scopes.push({{path}})
@@ -26,13 +26,11 @@ module Grip
 
         {{yield}}
 
-        @valves.pop() if @valves.size != 0 && @valves.size != size
+        @valves.pop(@valves.size - %size)
 
         if {{path}} != "/"
           @scopes.pop()
         end
-
-        @valves.pop() if @scopes.size == 0 && @valves.size != 0
       end
 
       {% for http_method in HTTP_METHODS %}


### PR DESCRIPTION
Snippet to reproduce the issue:

```crystal
require "grip"

class HeaderHandler
  include HTTP::Handler

  def initialize(@name : String, @value : String)
  end

  def call(context : HTTP::Server::Context) : HTTP::Server::Context
    context.put_resp_header(@name, @value)
  end
end

class EmptyController < Grip::Controllers::Http
end

class Application < Grip::Application
  def initialize
    super(environment: "development", serve_static: false)

    pipeline :foo, [HeaderHandler.new("X-Foo", "foo")]
    pipeline :bar, [HeaderHandler.new("X-Bar", "bar")]
    pipeline :baz, [HeaderHandler.new("X-Baz", "baz")]

    scope "/" do
      pipe_through :foo
      pipe_through :bar

      get "/before", EmptyController

      scope "/first" do
        get "/", EmptyController
      end

      scope "/second" do
        pipe_through :baz
        get "/", EmptyController
      end

      get "/after", EmptyController
    end
  end
end

Application.new.run
```

In this snippet, I expected all routes to append `X-Foo` and `X-Bar` headers, and additionaly, route `/second` with `X-Baz`.

What currently happens (grip v2.0.3) is that after each scope one pipeline is discarded (even if it wasn't declared in current scope's block), and possibly another one for the root scope case, resulting in incorrect pipeline propagation:

- `/before` returns `X-Foo` and `X-Bar` - ok
- `/first` returns `X-Foo` and `X-Bar` - headers ok, unexpected discard of `:bar` pipeline
- `/second` returns `X-Foo` and `X-Baz` - missing `X-Bar`, unexpected discard of `:foo` pipeline (`@scopes.size == 0` case)
- `/after` doesn't return any headers