### PR TITLE
Add boolean flag skip_router to Context

### DIFF
--- a/src/grip/application.cr
+++ b/src/grip/application.cr
@@ -15,7 +15,7 @@ module Grip
     getter scopes : Array(String) = [] of String
     getter valves : Array(Symbol) = [] of Symbol
     getter valve : Symbol?
-    
+
     property router : Array(HTTP::Handler)
 
     def initialize(@environment : String = "development")

--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -157,6 +157,7 @@ module Grip
 
       def exec
         with self yield
+        self
       end
     end
   end

--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -3,6 +3,7 @@ module Grip
     module Context
       property exception : Exception?
       property parameters : Grip::Parsers::ParameterBox?
+      property? skip_router : Bool = false
 
       # Deletes request header.
       def delete_req_header(key)

--- a/src/grip/routers/http.cr
+++ b/src/grip/routers/http.cr
@@ -11,7 +11,7 @@ module Grip
       end
 
       def call(context : HTTP::Server::Context)
-        return context if context.response.closed?
+        return context if context.skip_router? || context.response.closed?
 
         route = find_route(context.request.method.as(String), context.request.path)
         route = find_route("ALL", context.request.path) unless route.found?

--- a/src/grip/routers/websocket.cr
+++ b/src/grip/routers/websocket.cr
@@ -11,6 +11,8 @@ module Grip
       end
 
       def call(context : HTTP::Server::Context)
+        return context if context.skip_router? || context.response.closed?
+
         route = find_route("", context.request.path)
 
         unless route.found? && websocket_upgrade_request?(context)


### PR DESCRIPTION
### Description of the Change
Allow skipping http_handler and websocket_handler by setting skip_router to `true` on Context
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
It allows skipping router handlers from Grip pipelines.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
