### PR TITLE
Don't send `charset` with `application/json` content type

### DIFF
--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -80,18 +80,6 @@ describe "Context" do
       ("UTF-8".in? client_response.headers["Content-Type"]).should be_true
     end
 
-    it "encodes json in utf-8" do
-      http_handler = Grip::Routers::Http.new
-      http_handler.add_route "GET", "/", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do
-        context.json({:message => "👋🏼 grip"}).halt
-      end
-
-      request = HTTP::Request.new("GET", "/")
-      client_response = call_request_on_app(request, http_handler)
-      client_response.body.should eq "{\"message\":\"👋🏼 grip\"}"
-      ("UTF-8".in? client_response.headers["Content-Type"]).should be_true
-    end
-
     it "encodes html in utf-8" do
       http_handler = Grip::Routers::Http.new
       http_handler.add_route "GET", "/", ExampleController.new, [:none], ->(context : HTTP::Server::Context) do

--- a/src/grip/extensions/context.cr
+++ b/src/grip/extensions/context.cr
@@ -92,7 +92,7 @@ module Grip
       end
 
       # Sends a response with the content formated as json.
-      def json(content, content_type = "application/json; charset=UTF-8")
+      def json(content, content_type = "application/json")
         @response.headers.merge!({"Content-Type" => content_type})
         @response.print(content.to_json)
         self


### PR DESCRIPTION
### Description of the Change

According to [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)

> JSON text SHALL be encoded in Unicode. The default encoding is UTF-8.

"SHALL" represents an absolute requirement here (see [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)).