### PR TITLE
Enclose the project directory path with double quotes

### DIFF
--- a/src/grip/version.cr
+++ b/src/grip/version.cr
@@ -1,3 +1,3 @@
 module Grip
-  VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end


### PR DESCRIPTION
### Description of the Change

This change makes sure that the computation of `Grip::VERSION` constant doesn't break when project path contains spaces.