### PR TITLE
Make `Application#scheme` a public method

### DIFF
--- a/src/grip/application.cr
+++ b/src/grip/application.cr
@@ -78,7 +78,7 @@ module Grip
       end
     {% end %}
 
-    protected def scheme : String
+    def scheme : String
       ssl ? "https" : "http"
     end
 


### PR DESCRIPTION
### Description of the Change

Turns `Application#scheme` into a public method. This allows other tools to use it directly, instead of duplicating the logic by using `ssl ? "https" : "http"` condition. This would come handy for instance in a [raven.cr](https://github.com/Sija/raven.cr) shard, in which there's a need to reconstruct full request url for the logging purposes.